### PR TITLE
Mac support for LsCpp

### DIFF
--- a/LizardScript/LizardScript/LsCppSettingsExample(Mac).txt
+++ b/LizardScript/LizardScript/LsCppSettingsExample(Mac).txt
@@ -1,0 +1,3 @@
+"/Users/TwoDollarsEsq/Developer/Pets/lizardscript/LizardScript/LizardScript/LizardScriptCore.a"
+"/Users/TwoDollarsEsq/Developer/Pets/lizardscript/LizardScript/LizardScriptCore"
+clang++ --std=c++14 $INPUT_FILE -o test $LS_CORE_LIB_DIR -O2 -I $LS_CORE_SRC_DIR

--- a/LizardScript/LizardScriptCore/LsCpp.h
+++ b/LizardScript/LizardScriptCore/LsCpp.h
@@ -78,7 +78,7 @@ struct LsCppCompilerCall
 		stringReplace(new_compiler_call_string, "$LS_CORE_SRC_DIR", path_to_lizard_script_core_src);
 
 		std::cout << new_compiler_call_string.c_str();
-		system((std::string("\"") + new_compiler_call_string + "\"").c_str());
+		system(new_compiler_call_string.c_str());
 
 		std::string output_path = input_path;
 		stringReplace(output_path, ".cxx", executable_extension);


### PR DESCRIPTION
Adds `LsCppSettingsExample(Mac).txt` and removes wrapping into `"` for path variable.